### PR TITLE
Harden DNS views and fix API calls in templates

### DIFF
--- a/Servicedns/Service.php
+++ b/Servicedns/Service.php
@@ -44,7 +44,13 @@ class Service implements InjectionAwareInterface
 
     public function attachOrderConfig(\Model_Product $product, array $data): array
     {
-        !empty($product->config) ? $config = json_decode($product->config, true) : $config = [];
+        $config = [];
+        if (!empty($product->config)) {
+            $decoded = json_decode($product->config, true);
+            if (is_array($decoded)) {
+                $config = $decoded;
+            }
+        }
 
         return array_merge($config, $data);
     }
@@ -237,7 +243,7 @@ class Service implements InjectionAwareInterface
             'updated_at' => $model->updated_at,
             'domain_name' => $model->domain_name,
             'records' => $records,
-            'config' => json_decode($model->config, true),
+            'config' => json_decode($model->config, true) ?: [],
         ];
     }
 

--- a/Servicedns/Service.php
+++ b/Servicedns/Service.php
@@ -236,6 +236,7 @@ class Service implements InjectionAwareInterface
     {
         $domain_id = $this->di['db']->findOne('service_dns', 'domain_name = :domain_name', [':domain_name' => $model->domain_name]);
         $records = $this->di['db']->getAll('SELECT id, type, host, value, ttl, priority FROM service_dns_records WHERE domain_id=:domain_id', ['domain_id' => $domain_id['id']]);
+        $decodedConfig = json_decode((string) $model->config, true);
 
         return [
             'id' => $model->id,
@@ -243,7 +244,7 @@ class Service implements InjectionAwareInterface
             'updated_at' => $model->updated_at,
             'domain_name' => $model->domain_name,
             'records' => $records,
-            'config' => json_decode($model->config, true) ?: [],
+            'config' => is_array($decodedConfig) ? $decodedConfig : [],
         ];
     }
 

--- a/Servicedns/templates/admin/mod_servicedns_config.html.twig
+++ b/Servicedns/templates/admin/mod_servicedns_config.html.twig
@@ -1,4 +1,5 @@
 {% import 'macro_functions.html.twig' as mf %}
+{% set config = product.config|default({}) %}
     <div class="card-body">
         <h1>{{ 'DNS Provider settings'|trans }}</h1>
         <form action="{{ 'product/update_config'|api_url(role='admin') }}" {{ fb_api_form({ message: 'DNS Provider settings updated'|trans }) }}>
@@ -7,17 +8,17 @@
                 <label class="form-label col-3 col-form-label">{{ 'Provider'|trans }}:</label>
                 <div class="col">
                     <select class="form-select" name="config[provider]" required>
-                        <option value="" disabled {% if not product.config.provider %}selected{% endif %}>Select Provider</option>
-                        <option value="AnycastDNS" {% if product.config.provider == 'AnycastDNS' %}selected{% endif %}>AnycastDNS</option>
-                        <option value="Bind" {% if product.config.provider == 'Bind' %}selected{% endif %}>Bind</option>
-                        <option value="Bunny" {% if product.config.provider == 'Bunny' %}selected{% endif %}>Bunny</option>
-                        <option value="Cloudflare" {% if product.config.provider == 'Cloudflare' %}selected{% endif %}>Cloudflare</option>
-                        <option value="ClouDNS" {% if product.config.provider == 'ClouDNS' %}selected{% endif %}>ClouDNS</option>
-                        <option value="Desec" {% if product.config.provider == 'Desec' %}selected{% endif %}>Desec</option>
-                        <option value="DNSimple" {% if product.config.provider == 'DNSimple' %}selected{% endif %}>DNSimple</option>
-                        <option value="Hetzner" {% if product.config.provider == 'Hetzner' %}selected{% endif %}>Hetzner</option>
-                        <option value="PowerDNS" {% if product.config.provider == 'PowerDNS' %}selected{% endif %}>PowerDNS</option>
-                        <option value="Vultr" {% if product.config.provider == 'Vultr' %}selected{% endif %}>Vultr</option>
+                        <option value="" disabled {% if config.provider|default('') == '' %}selected{% endif %}>Select Provider</option>
+                        <option value="AnycastDNS" {% if config.provider|default('') == 'AnycastDNS' %}selected{% endif %}>AnycastDNS</option>
+                        <option value="Bind" {% if config.provider|default('') == 'Bind' %}selected{% endif %}>Bind</option>
+                        <option value="Bunny" {% if config.provider|default('') == 'Bunny' %}selected{% endif %}>Bunny</option>
+                        <option value="Cloudflare" {% if config.provider|default('') == 'Cloudflare' %}selected{% endif %}>Cloudflare</option>
+                        <option value="ClouDNS" {% if config.provider|default('') == 'ClouDNS' %}selected{% endif %}>ClouDNS</option>
+                        <option value="Desec" {% if config.provider|default('') == 'Desec' %}selected{% endif %}>Desec</option>
+                        <option value="DNSimple" {% if config.provider|default('') == 'DNSimple' %}selected{% endif %}>DNSimple</option>
+                        <option value="Hetzner" {% if config.provider|default('') == 'Hetzner' %}selected{% endif %}>Hetzner</option>
+                        <option value="PowerDNS" {% if config.provider|default('') == 'PowerDNS' %}selected{% endif %}>PowerDNS</option>
+                        <option value="Vultr" {% if config.provider|default('') == 'Vultr' %}selected{% endif %}>Vultr</option>
                     </select>
                 </div>
             </div>
@@ -25,7 +26,7 @@
                 <p>{{ 'Enter your DNS provider\'s API key. Keep it confidential and ensure it\'s valid for requests.'|trans }}</p>
                 <label class="form-label col-3 col-form-label">{{ 'API Key'|trans }}:</label>
                 <div class="col">
-                    <input type="text" class="form-control" name="config[apikey]" value="{{ product.config.apikey }}">
+                    <input type="text" class="form-control" name="config[apikey]" value="{{ config.apikey|default('') }}">
                 </div>
             </div>
             <div class="hr-text">
@@ -35,52 +36,52 @@
                 <p>{{ 'Specify the email address for the responsible person of this DNS zone. This address is used in the SOA (Start of Authority) record.'|trans }}</p>
                 <label class="form-label col-3 col-form-label">{{ 'SOA Email'|trans }}:</label>
                 <div class="col">
-                    <input type="text" class="form-control" name="config[soaemail]" placeholder="test@example.com" value="{{ product.config.soaemail }}">
+                    <input type="text" class="form-control" name="config[soaemail]" placeholder="test@example.com" value="{{ config.soaemail|default('') }}">
                 </div>
             </div>
             <div class="mb-3 row">
                 <p>{{ 'Enter the IP address of your BIND server where the API is accessible.'|trans }}</p>
                 <label class="form-label col-3 col-form-label">{{ 'BIND API IP'|trans }}:</label>
                 <div class="col">
-                    <input type="text" class="form-control" name="config[bindip]" placeholder="127.0.0.1" value="{{ product.config.bindip }}">
+                    <input type="text" class="form-control" name="config[bindip]" placeholder="127.0.0.1" value="{{ config.bindip|default('') }}">
                 </div>
             </div>
             <div class="mb-3 row">
                 <p>{{ 'Enter the IP address of your PowerDNS server where the API is accessible.'|trans }}</p>
                 <label class="form-label col-3 col-form-label">{{ 'PowerDNS API IP'|trans }}:</label>
                 <div class="col">
-                    <input type="text" class="form-control" name="config[powerdnsip]" placeholder="127.0.0.1" value="{{ product.config.powerdnsip }}">
+                    <input type="text" class="form-control" name="config[powerdnsip]" placeholder="127.0.0.1" value="{{ config.powerdnsip|default('') }}">
                 </div>
             </div>
             <div class="mb-3 row">
                 <p>{{ 'Enter the nameservers for your DNS zone.'|trans }}</p>
                 <label class="form-label col-3 col-form-label">{{ 'NS1'|trans }}:</label>
                 <div class="col">
-                    <input type="text" class="form-control" name="config[ns1]" placeholder="ns1.example.com" value="{{ product.config.ns1 }}">
+                    <input type="text" class="form-control" name="config[ns1]" placeholder="ns1.example.com" value="{{ config.ns1|default('') }}">
                 </div>
             </div>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'NS2'|trans }}:</label>
                 <div class="col">
-                    <input type="text" class="form-control" name="config[ns2]" placeholder="ns2.example.com" value="{{ product.config.ns2 }}">
+                    <input type="text" class="form-control" name="config[ns2]" placeholder="ns2.example.com" value="{{ config.ns2|default('') }}">
                 </div>
             </div>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'NS3'|trans }}:</label>
                 <div class="col">
-                    <input type="text" class="form-control" name="config[ns3]" placeholder="ns3.example.com" value="{{ product.config.ns3 }}">
+                    <input type="text" class="form-control" name="config[ns3]" placeholder="ns3.example.com" value="{{ config.ns3|default('') }}">
                 </div>
             </div>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'NS4'|trans }}:</label>
                 <div class="col">
-                    <input type="text" class="form-control" name="config[ns4]" placeholder="ns4.example.com" value="{{ product.config.ns4 }}">
+                    <input type="text" class="form-control" name="config[ns4]" placeholder="ns4.example.com" value="{{ config.ns4|default('') }}">
                 </div>
             </div>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'NS5'|trans }}:</label>
                 <div class="col">
-                    <input type="text" class="form-control" name="config[ns5]" placeholder="ns5.example.com" value="{{ product.config.ns5 }}">
+                    <input type="text" class="form-control" name="config[ns5]" placeholder="ns5.example.com" value="{{ config.ns5|default('') }}">
                 </div>
             </div>
             

--- a/Servicedns/templates/admin/mod_servicedns_manage.html.twig
+++ b/Servicedns/templates/admin/mod_servicedns_manage.html.twig
@@ -1,6 +1,6 @@
 {% import 'macro_functions.html.twig' as mf %}
 
-{% set service = admin.order_service({ "id": order.id }) %}
+{% set service = admin.order_service({ "id": order.id })|default({}) %}
 <div class="card mb-4">
     <div class="card-body overflow-auto">
         <h3>{{ 'DNS Record Management'|trans }}</h3>
@@ -51,7 +51,7 @@
                     </tr>
                 </thead>
                     <tbody id="recordsTableBody">
-                        {% for record in service.records %}
+                        {% for record in service.records|default([]) %}
                         <form class="mb-4 api-form" action="{{ 'servicedns/update'|api_url(role='client') }}" {{ fb_api_form({ message: 'Record updated'|trans }) }}>
                         <input type="hidden" name="record_id" value="{{ record.id }}"/>
                         <input type="hidden" name="record_type" value="{{ record.type }}"/>
@@ -69,7 +69,7 @@
                                 {% elseif dns_type == 'SPF' %}bg-red-lt
                                 {% elseif dns_type == 'DS' %}bg-purple-lt
                                 {% else %}bg-default
-                                {% endif %}">{{ dns_type }}</span></td></td>
+                                {% endif %}">{{ dns_type }}</span></td>
                                 <td><strong>{{ record.host }}</strong></td>
                                 <td><input type="text" class="form-control" placeholder="127.0.0.1" name="record_value" value="{{ record.value }}" style="min-width:200px;" required></td>
                                 <td><input type="text" class="form-control" placeholder="600" name="record_ttl" value="{{ record.ttl }}" style="min-width:100px;" required></td>
@@ -103,7 +103,7 @@ function confirmDelete(form) {
     event.preventDefault();
 
     if (confirm("Are you sure you want to delete this record?")) {
-        fetch("{{ 'api/client/servicedns/del'|url }}", {
+        fetch("{{ 'servicedns/del'|api_url(role='client') }}", {
             method: 'POST',
             body: new FormData(form),
             headers: {

--- a/Servicedns/templates/admin/mod_servicedns_manage.html.twig
+++ b/Servicedns/templates/admin/mod_servicedns_manage.html.twig
@@ -5,7 +5,7 @@
     <div class="card-body overflow-auto">
         <h3>{{ 'DNS Record Management'|trans }}</h3>
         
-        <form class="mb-4 api-form" action="{{ 'servicedns/add'|api_url(role='client') }}" {{ fb_api_form({ message: 'New Record Added'|trans }) }}>
+        <form class="mb-4 api-form" action="{{ 'servicedns/add'|api_url(role='admin') }}" {{ fb_api_form({ message: 'New Record Added'|trans }) }}>
             <div class="row g-3">
                 <div class="col-md-2">
                     <select class="form-select" name="record_type" required>
@@ -52,12 +52,7 @@
                 </thead>
                     <tbody id="recordsTableBody">
                         {% for record in service.records|default([]) %}
-                        <form class="mb-4 api-form" action="{{ 'servicedns/update'|api_url(role='client') }}" {{ fb_api_form({ message: 'Record updated'|trans }) }}>
-                        <input type="hidden" name="record_id" value="{{ record.id }}"/>
-                        <input type="hidden" name="record_type" value="{{ record.type }}"/>
-                        <input type="hidden" name="record_name" value="{{ record.host }}"/>
-                        <input type="hidden" name="old_value" value="{{ record.value }}"/>
-                        <input type="hidden" name="order_id" value="{{ order.id }}">
+                            {% set record_form_id = 'dns-record-' ~ record.id %}
                             <tr>
                                 <td>{% set dns_type = record.type|upper %}
                                 <span class="badge 
@@ -71,19 +66,26 @@
                                 {% else %}bg-default
                                 {% endif %}">{{ dns_type }}</span></td>
                                 <td><strong>{{ record.host }}</strong></td>
-                                <td><input type="text" class="form-control" placeholder="127.0.0.1" name="record_value" value="{{ record.value }}" style="min-width:200px;" required></td>
-                                <td><input type="text" class="form-control" placeholder="600" name="record_ttl" value="{{ record.ttl }}" style="min-width:100px;" required></td>
-                                <td> {% if record.type == 'MX' %} <span class="badge bg-dark-lt">{{ record.priority }}</span> <input type="hidden" name="record_priority" value="{{ record.priority }}"> {% endif %} </td>
+                                <td><input type="text" class="form-control" placeholder="127.0.0.1" name="record_value" value="{{ record.value }}" form="{{ record_form_id }}" style="min-width:200px;" required></td>
+                                <td><input type="text" class="form-control" placeholder="600" name="record_ttl" value="{{ record.ttl }}" form="{{ record_form_id }}" style="min-width:100px;" required></td>
+                                <td>{% if record.type == 'MX' %}<span class="badge bg-dark-lt">{{ record.priority }}</span>{% endif %}</td>
                                 <td>
-                                    <button type="submit" class="btn btn-outline-primary btn-icon" name="action" value="update" title="Update Record">
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1" /><path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z" /><path d="M16 5l3 3" /></svg>
-                                    </button>
-                                    <button type="button" class="btn btn-outline-danger btn-icon" title="Delete Record" onclick="confirmDelete(this.form)">
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M10 10l4 4m0 -4l-4 4" /></svg>
-                                    </button>
+                                    <form id="{{ record_form_id }}" class="d-inline-flex gap-1" action="{{ 'servicedns/update'|api_url(role='admin') }}" {{ fb_api_form({ message: 'Record updated'|trans }) }}>
+                                        <input type="hidden" name="record_id" value="{{ record.id }}"/>
+                                        <input type="hidden" name="record_type" value="{{ record.type }}"/>
+                                        <input type="hidden" name="record_name" value="{{ record.host }}"/>
+                                        <input type="hidden" name="old_value" value="{{ record.value }}"/>
+                                        <input type="hidden" name="order_id" value="{{ order.id }}">
+                                        {% if record.type == 'MX' %}<input type="hidden" name="record_priority" value="{{ record.priority }}">{% endif %}
+                                        <button type="submit" class="btn btn-outline-primary btn-icon" name="action" value="update" title="Update Record">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1" /><path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z" /><path d="M16 5l3 3" /></svg>
+                                        </button>
+                                        <button type="button" class="btn btn-outline-danger btn-icon" title="Delete Record" onclick="confirmDelete(event, this.form)">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M10 10l4 4m0 -4l-4 4" /></svg>
+                                        </button>
+                                    </form>
                                 </td>
                             </tr>
-                        </form>
                         {% else %}
                             <tr>
                                 <td colspan="6">No DNS records found.</td>
@@ -94,27 +96,21 @@
         </div>
     </div>
     <div class="card-footer text-center">
-        {{ order_actions }}
+        {{ order_actions|default('') }}
     </div>
 </div>
 
 <script> 
-function confirmDelete(form) {
+function confirmDelete(event, form) {
     event.preventDefault();
 
     if (confirm("Are you sure you want to delete this record?")) {
-        fetch("{{ 'servicedns/del'|api_url(role='client') }}", {
-            method: 'POST',
-            body: new FormData(form),
-            headers: {
-                'Accept': 'application/json'
-            }
-        })
-        .then(response => response.json())
-        .then(data => {
-            window.location.reload();
-        })
-        .catch(error => console.error('Error:', error));
+        FOSSBilling.api.admin.post(
+            'servicedns/del',
+            new FormData(form),
+            () => window.location.reload(),
+            error => console.error('Error:', error)
+        );
     }
 }
 

--- a/Servicedns/templates/client/mod_servicedns_manage.html.twig
+++ b/Servicedns/templates/client/mod_servicedns_manage.html.twig
@@ -52,7 +52,7 @@
                     </tr>
                 </thead>
                     <tbody id="recordsTableBody">
-                        {% for record in service.records %}
+                        {% for record in service.records|default([]) %}
                         <form class="mb-4 api-form" action="{{ 'servicedns/update'|api_url(role='client') }}" {{ fb_api_form({ message: 'Record updated'|trans }) }}>
                         <input type="hidden" name="record_id" value="{{ record.id }}"/>
                         <input type="hidden" name="record_type" value="{{ record.type }}"/>
@@ -101,7 +101,7 @@ function confirmDelete(form) {
     event.preventDefault();
 
     if (confirm("Are you sure you want to delete this record?")) {
-        fetch("{{ 'api/client/servicedns/del'|url }}", {
+        fetch("{{ 'servicedns/del'|api_url(role='client') }}", {
             method: 'POST',
             body: new FormData(form),
             headers: {

--- a/Servicedns/templates/client/mod_servicedns_manage.html.twig
+++ b/Servicedns/templates/client/mod_servicedns_manage.html.twig
@@ -53,12 +53,7 @@
                 </thead>
                     <tbody id="recordsTableBody">
                         {% for record in service.records|default([]) %}
-                        <form class="mb-4 api-form" action="{{ 'servicedns/update'|api_url(role='client') }}" {{ fb_api_form({ message: 'Record updated'|trans }) }}>
-                        <input type="hidden" name="record_id" value="{{ record.id }}"/>
-                        <input type="hidden" name="record_type" value="{{ record.type }}"/>
-                        <input type="hidden" name="record_name" value="{{ record.host }}"/>
-                        <input type="hidden" name="old_value" value="{{ record.value }}"/>
-                        <input type="hidden" name="order_id" value="{{ order.id }}">
+                            {% set record_form_id = 'dns-record-' ~ record.id %}
                             <tr>
                                 <td>{% set dns_type = record.type|upper %}
                                 <span class="badge 
@@ -72,19 +67,26 @@
                                 {% else %}bg-default
                                 {% endif %}">{{ dns_type }}</span></td>
                                 <td><strong>{{ record.host }}</strong></td>
-                                <td><input type="text" class="form-control" placeholder="127.0.0.1" name="record_value" value="{{ record.value }}" style="min-width:200px;" required></td>
-                                <td><input type="text" class="form-control" placeholder="600" name="record_ttl" value="{{ record.ttl }}" style="min-width:100px;" required></td>
-                                <td> {% if record.type == 'MX' %} <span class="badge bg-dark-lt">{{ record.priority }}</span> <input type="hidden" name="record_priority" value="{{ record.priority }}"> {% endif %} </td>
+                                <td><input type="text" class="form-control" placeholder="127.0.0.1" name="record_value" value="{{ record.value }}" form="{{ record_form_id }}" style="min-width:200px;" required></td>
+                                <td><input type="text" class="form-control" placeholder="600" name="record_ttl" value="{{ record.ttl }}" form="{{ record_form_id }}" style="min-width:100px;" required></td>
+                                <td>{% if record.type == 'MX' %}<span class="badge bg-dark-lt">{{ record.priority }}</span>{% endif %}</td>
                                 <td class="text-end">
-                                    <button type="submit" class="btn btn-outline-primary btn-icon" name="action" value="update" title="Update Record">
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1" /><path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z" /><path d="M16 5l3 3" /></svg>
-                                    </button>
-                                    <button type="button" class="btn btn-outline-danger btn-icon" title="Delete Record" onclick="confirmDelete(this.form)">
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M10 10l4 4m0 -4l-4 4" /></svg>
-                                    </button>
+                                    <form id="{{ record_form_id }}" class="d-inline-flex gap-1" action="{{ 'servicedns/update'|api_url(role='client') }}" {{ fb_api_form({ message: 'Record updated'|trans }) }}>
+                                        <input type="hidden" name="record_id" value="{{ record.id }}"/>
+                                        <input type="hidden" name="record_type" value="{{ record.type }}"/>
+                                        <input type="hidden" name="record_name" value="{{ record.host }}"/>
+                                        <input type="hidden" name="old_value" value="{{ record.value }}"/>
+                                        <input type="hidden" name="order_id" value="{{ order.id }}">
+                                        {% if record.type == 'MX' %}<input type="hidden" name="record_priority" value="{{ record.priority }}">{% endif %}
+                                        <button type="submit" class="btn btn-outline-primary btn-icon" name="action" value="update" title="Update Record">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1" /><path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z" /><path d="M16 5l3 3" /></svg>
+                                        </button>
+                                        <button type="button" class="btn btn-outline-danger btn-icon" title="Delete Record" onclick="confirmDelete(event, this.form)">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M10 10l4 4m0 -4l-4 4" /></svg>
+                                        </button>
+                                    </form>
                                 </td>
                             </tr>
-                        </form>
                         {% else %}
                             <tr>
                                 <td colspan="6">No DNS records found.</td>
@@ -97,22 +99,16 @@
 </div>
 
 <script>
-function confirmDelete(form) {
+function confirmDelete(event, form) {
     event.preventDefault();
 
     if (confirm("Are you sure you want to delete this record?")) {
-        fetch("{{ 'servicedns/del'|api_url(role='client') }}", {
-            method: 'POST',
-            body: new FormData(form),
-            headers: {
-                'Accept': 'application/json'
-            }
-        })
-        .then(response => response.json())
-        .then(data => {
-            window.location.reload();
-        })
-        .catch(error => console.error('Error:', error));
+        FOSSBilling.api.client.post(
+            'servicedns/del',
+            new FormData(form),
+            () => window.location.reload(),
+            error => console.error('Error:', error)
+        );
     }
 }
 

--- a/Servicedns/templates/client/mod_servicedns_order_form.html.twig
+++ b/Servicedns/templates/client/mod_servicedns_order_form.html.twig
@@ -1,3 +1,4 @@
+{% set config = product.config|default({}) %}
 {{ product_details }}
 
 <div class="mb-3">
@@ -24,8 +25,8 @@
     <ul>
       {% for i in 1..5 %}
         {% set key = 'ns' ~ i %}
-        {% if product.config[key] is defined and product.config[key] %}
-          <li>{{ product.config[key] }}</li>
+        {% if config[key] is defined and config[key] %}
+          <li>{{ config[key] }}</li>
         {% endif %}
       {% endfor %}
     </ul>

--- a/Servicedns/templates/email/mod_servicedns_activated.html.twig
+++ b/Servicedns/templates/email/mod_servicedns_activated.html.twig
@@ -1,4 +1,4 @@
-{% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Activated{% endblock %}
+{% block subject %}[{{ guest.system_company.name|default('') }}] {{ order.title }} Activated{% endblock %}
 {% block content %}
 <!DOCTYPE html>
 <html>
@@ -39,11 +39,11 @@
 	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
 	<p>Your <strong>{{ order.title }}</strong> is now activated.</p>
 
-    <p><strong>Domain name:</strong> {{ service.domain_name }}</p>
+    <p><strong>Domain name:</strong> {{ service.domain_name|default('') }}</p>
 
     <p>You may <a href="{{'login'|url({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|url }}/{{ order.id }}" target="_blank">manage your order.</a>
 
-	<p class="signature">{{ guest.system_company.signature }}</p>
+	<p class="signature">{{ guest.system_company.signature|default('') }}</p>
 </body>
 </html>
 {% endblock %}

--- a/Servicedns/templates/email/mod_servicedns_canceled.html.twig
+++ b/Servicedns/templates/email/mod_servicedns_canceled.html.twig
@@ -1,4 +1,4 @@
-{% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Canceled{% endblock %}
+{% block subject %}[{{ guest.system_company.name|default('') }}] {{ order.title }} Canceled{% endblock %}
 {% block content %}
 <!DOCTYPE html>
 <html>
@@ -37,16 +37,16 @@
 <body>
 	<h1>Order canceled</h1>
 	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
-	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now canceled.</p>
-    {% if order.reason %}
-        <p><strong>Reason:</strong> {{ order.reason }}</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{% if order.activated_at is defined %}{{ order.activated_at|format_date }}{% endif %}</strong> is now canceled.</p>
+    {% if order.reason|default is not empty %}
+        <p><strong>Reason:</strong> {{ order.reason|default('') }}</p>
     {% endif %}
 
     <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
     <p>You may <a href="{{'login'|url({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|url({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-	<p class="signature">{{ guest.system_company.signature }}</p>
+	<p class="signature">{{ guest.system_company.signature|default('') }}</p>
 </body>
 </html>
 {% endblock %}

--- a/Servicedns/templates/email/mod_servicedns_renewed.html.twig
+++ b/Servicedns/templates/email/mod_servicedns_renewed.html.twig
@@ -1,4 +1,4 @@
-{% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Renewed{% endblock %}
+{% block subject %}[{{ guest.system_company.name|default('') }}] {{ order.title }} Renewed{% endblock %}
 {% block content %}
 <!DOCTYPE html>
 <html>
@@ -38,13 +38,13 @@
 	<h1>Order renewed</h1>
 	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
 	<p>Your <strong>{{ order.title }}</strong> has been renewed.</p>
-    {% if order.expires_at %}
+    {% if order.expires_at is defined %}
         <p><strong>Next renewal date:</strong> {{ order.expires_at|format_date }}</p>
     {% endif %}
 
     <p>You may <a href="{{'login'|url({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|url }}/{{ order.id }}" target="_blank">manage your order.</a>
 
-	<p class="signature">{{ guest.system_company.signature }}</p>
+	<p class="signature">{{ guest.system_company.signature|default('') }}</p>
 </body>
 </html>
 {% endblock %}

--- a/Servicedns/templates/email/mod_servicedns_suspended.html.twig
+++ b/Servicedns/templates/email/mod_servicedns_suspended.html.twig
@@ -1,4 +1,4 @@
-{% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Suspended{% endblock %}
+{% block subject %}[{{ guest.system_company.name|default('') }}] {{ order.title }} Suspended{% endblock %}
 {% block content %}
 <!DOCTYPE html>
 <html>
@@ -37,16 +37,16 @@
 <body>
 	<h1>Order suspended</h1>
 	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
-	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now suspended.</p>
-    {% if order.reason %}
-        <p><strong>Reason:</strong> {{ order.reason }}</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{% if order.activated_at is defined %}{{ order.activated_at|format_date }}{% endif %}</strong> is now suspended.</p>
+    {% if order.reason|default is not empty %}
+        <p><strong>Reason:</strong> {{ order.reason|default('') }}</p>
     {% endif %}
 
     <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
     <p>You may <a href="{{'login'|url({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|url({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-	<p class="signature">{{ guest.system_company.signature }}</p>
+	<p class="signature">{{ guest.system_company.signature|default('') }}</p>
 </body>
 </html>
 {% endblock %}

--- a/Servicedns/templates/email/mod_servicedns_unsuspended.html.twig
+++ b/Servicedns/templates/email/mod_servicedns_unsuspended.html.twig
@@ -1,4 +1,4 @@
-{% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Reactivated{% endblock %}
+{% block subject %}[{{ guest.system_company.name|default('') }}] {{ order.title }} Reactivated{% endblock %}
 {% block content %}
 <!DOCTYPE html>
 <html>
@@ -41,7 +41,7 @@
 
     <p>You may <a href="{{'login'|url({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|url }}/{{ order.id }}" target="_blank">manage your order.</a>
 
-	<p class="signature">{{ guest.system_company.signature }}</p>
+	<p class="signature">{{ guest.system_company.signature|default('') }}</p>
 </body>
 </html>
 {% endblock %}


### PR DESCRIPTION
Improves handling and rendering of DNS service configuration and record management in both the admin and client interfaces. 

Fixes issues such as known failure: “Key 'provider' does not exist as the sequence/mapping is empty in `mod_servicedns_config.html.twig` at line 10.”

*Recommend testing with live system running the module; this was not available at time of PR.*